### PR TITLE
build and publish app inside docker container

### DIFF
--- a/DockerDotnetApiTutorial.Api/Dockerfile
+++ b/DockerDotnetApiTutorial.Api/Dockerfile
@@ -1,7 +1,13 @@
-FROM microsoft/dotnet:2.1-aspnetcore-runtime
-
-COPY ./bin/Debug/netcoreapp2.1/publish /opt/coreapp/
+FROM microsoft/dotnet:2.1-sdk AS build
+COPY ./ /opt/coreapp/
 
 WORKDIR /opt/coreapp/
+RUN dotnet restore
+RUN dotnet publish -c Release -o out
+
+FROM microsoft/dotnet:2.1-aspnetcore-runtime
+WORKDIR /opt/coreapp/
+
+COPY --from=build /opt/coreapp/out ./
 
 ENTRYPOINT ["dotnet", "DockerDotnetApiTutorial.Api.dll"]

--- a/DockerDotnetApiTutorial.Api/Dockerfile
+++ b/DockerDotnetApiTutorial.Api/Dockerfile
@@ -1,13 +1,23 @@
+# Create build containber
 FROM microsoft/dotnet:2.1-sdk AS build
-COPY ./ /opt/coreapp/
-
 WORKDIR /opt/coreapp/
+
+# Restore packages used in the project.
+# Docker will cache this step until you change packege version or add new packages.
+# (All changes in the .csproj will result in rerunning this step on the next docker build.
+# Simple code changes will result in the docker deamon to reuse its cached intermediate container)
+COPY *.csproj /opt/coreapp/
 RUN dotnet restore
+
+# Actually build the application
+COPY ./ /opt/coreapp/
 RUN dotnet publish -c Release -o out
 
+# Create runtime container
 FROM microsoft/dotnet:2.1-aspnetcore-runtime
 WORKDIR /opt/coreapp/
 
+# Copy the build output from the build container
 COPY --from=build /opt/coreapp/out ./
 
 ENTRYPOINT ["dotnet", "DockerDotnetApiTutorial.Api.dll"]


### PR DESCRIPTION
Using this dockerfile will copy the entire Project inside a Container with installed dotnet SDK and publish it.
Therefore the Developer does not have to publish the app before building the Docker Image.

After the publish action has succeeded  the dockerfile creates a new Container with only the aspnetcore-runtime (no SDK thus much smaller) and copies the published folder from the "SDK-Container" to the "Runtime-Container".

Using this method will result in the same Image as result as your previous attempt with the benifit of not having to always publish the project manually.